### PR TITLE
Updated the printAll logic so it will print to the logger and not the co...

### DIFF
--- a/src/DbUp.Console/Program.cs
+++ b/src/DbUp.Console/Program.cs
@@ -1,31 +1,28 @@
-﻿using System;
-using System.IO;
-using System.Data.SqlClient;
+﻿using DbUp.Engine;
 using NDesk.Options;
-using DbUp.Engine;
+using System;
+using System.Data.SqlClient;
+using System.IO;
 
-namespace DbUp.Console
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var server = "";
-            var database = "";
-            var directory = "";
-            var username = "";
-            var password = "";
-            var connectionString = "";
-            var workingDir = "";
-            var dryrun = false;
-            var printAll = false;
-            var headVersion = "";
-            var promptUser = false;
-			var branch  = "";
+namespace DbUp.Console {
+	class Program {
+		static void Main(string[] args) {
+			var server = "";
+			var database = "";
+			var directory = "";
+			var username = "";
+			var password = "";
+			var connectionString = "";
+			var workingDir = "";
+			var dryrun = false;
+			var printAll = false;
+			var headVersion = "";
+			var promptUser = false;
+			var branch = "";
 
-            bool show_help = false;
+			bool show_help = false;
 
-            var optionSet = new OptionSet() {
+			var optionSet = new OptionSet() {
                 { "s|server=", "the SQL Server host", s => server = s },
                 { "db|database=", "database to upgrade", d => database = d},
                 { "d|directory=", "directory containing SQL Update files", dir => directory = dir },
@@ -40,95 +37,81 @@ namespace DbUp.Console
                 { "b|branch=", "Git branch to checkout and pull", b => branch = b }
             };
 
-            optionSet.Parse(args);
+			optionSet.Parse(args);
 
-            if (args.Length == 0)
-                show_help = true;
+			if (args.Length == 0) {
+				show_help = true;
+			}
 
-            if (show_help)
-            {
-                optionSet.WriteOptionDescriptions(System.Console.Out);
-                return;
+			if (show_help) {
+				optionSet.WriteOptionDescriptions(System.Console.Out);
+				return;
 
-            }
+			}
 
-            Directory.SetCurrentDirectory(workingDir);
+			Directory.SetCurrentDirectory(workingDir);
 
-            if (String.IsNullOrEmpty(connectionString))
-            {
-                connectionString = BuildConnectionString(server, database, username, password);
-            }
+			if (String.IsNullOrEmpty(connectionString)) {
+				connectionString = BuildConnectionString(server, database, username, password);
+			}
 
-            // Get the version hash of the database and repo@HEAD
-            branch = !String.IsNullOrEmpty(branch) ? branch : null;
-            DatabaseVersion databaseVersion = new DatabaseVersion(connectionString);
-            Git aGit = new Git(workingDir, branch);
-            aGit.UpdateLocalRepo();
-            headVersion = aGit.HeadVersion();
+			// Get the version hash of the database and repo@HEAD
+			branch = !String.IsNullOrEmpty(branch) ? branch : null;
+			DatabaseVersion databaseVersion = new DatabaseVersion(connectionString);
+			Git aGit = new Git(workingDir, branch);
+			aGit.UpdateLocalRepo();
+			headVersion = aGit.HeadVersion();
 
-            LogRunDetails(databaseVersion.Version, headVersion, connectionString, workingDir);
+			LogRunDetails(databaseVersion.Version, headVersion, connectionString, workingDir);
 
-            var dbup = DeployChanges.To
-                .SqlDatabase(connectionString)
-                .LogToConsole()
-                .WithScriptsFromFileSystem(directory)
-                .Build(branch);
+			var dbup = DeployChanges.To
+				.SqlDatabase(connectionString)
+				.LogToConsole()
+				.WithScriptsFromFileSystem(directory)
+				.Build(branch);
 
-            if (dryrun)
-            {
-                dbup.DryRun(databaseVersion.Version, headVersion, workingDir, printAll, connectionString);
-            }
-            else
-            {
-                if (dbup.IsUpgradeRequired(databaseVersion.Version, workingDir))
-                {
-                    if (dbup.PerformUpgrade(databaseVersion.Version, headVersion, workingDir, connectionString).Successful)
-                    {
-                        // Set the new database version
-                        databaseVersion.Version = headVersion;
-                        System.Console.WriteLine("Database updated to " + headVersion);
-                    }
-                }
-                else
-                {
-                    System.Console.WriteLine("\r\n\r\nDatabase already at newest version. Upgrade is not required.");
-                }
-            }
+			if (dryrun) {
+				dbup.DryRun(databaseVersion.Version, headVersion, workingDir, printAll, connectionString);
+			} else {
+				if (dbup.IsUpgradeRequired(databaseVersion.Version, workingDir)) {
+					if (dbup.PerformUpgrade(databaseVersion.Version, headVersion, workingDir, connectionString).Successful) {
+						// Set the new database version
+						databaseVersion.Version = headVersion;
+						System.Console.WriteLine("Database updated to {0}", headVersion);
+					}
+				} else {
+					System.Console.WriteLine("\r\n\r\nDatabase already at newest version. Upgrade is not required.");
+				}
+			}
 
-            if (promptUser)
-            {
-                System.Console.WriteLine("\r\n\r\nPress any key to continue.");
-                System.Console.ReadKey();
-            }
-        }
+			if (promptUser) {
+				System.Console.WriteLine("\r\n\r\nPress any key to continue.");
+				System.Console.ReadKey();
+			}
+		}
 
-        private static string BuildConnectionString(string server, string database, string username, string password)
-        {
-            var conn = new SqlConnectionStringBuilder();
-            conn.DataSource = server;
-            conn.InitialCatalog = database;
-            if (!String.IsNullOrEmpty(username))
-            {
-                conn.UserID = username;
-                conn.Password = password;
-                conn.IntegratedSecurity = false;
-            }
-            else
-            {
-                conn.IntegratedSecurity = true;
-            }
+		private static string BuildConnectionString(string server, string database, string username, string password) {
+			var conn = new SqlConnectionStringBuilder();
+			conn.DataSource = server;
+			conn.InitialCatalog = database;
+			if (!String.IsNullOrEmpty(username)) {
+				conn.UserID = username;
+				conn.Password = password;
+				conn.IntegratedSecurity = false;
+			} else {
+				conn.IntegratedSecurity = true;
+			}
 
-            return conn.ToString();
-        }
+			return conn.ToString();
+		}
 
-        private static void LogRunDetails(string databaseVersion, string headVersion, string connectionString, string workingDir)
-        {
-            System.Console.WriteLine("--------------------------------------------------------------------------------");
-            System.Console.WriteLine("Connection: " + connectionString);
-            System.Console.WriteLine("Working Directory: " + workingDir);
-            System.Console.WriteLine("DB Version: " + databaseVersion);
-            System.Console.WriteLine("HEAD Version: " + headVersion);
-            System.Console.WriteLine("--------------------------------------------------------------------------------");
-        }
-    }
+		private static void LogRunDetails(string databaseVersion, string headVersion, string connectionString, string workingDir) {
+			System.Console.WriteLine("--------------------------------------------------------------------------------");
+			System.Console.WriteLine("Connection: {0}", connectionString);
+			System.Console.WriteLine("Working Directory: {0}", workingDir);
+			System.Console.WriteLine("DB Version: {0}", databaseVersion);
+			System.Console.WriteLine("HEAD Version: {0}", headVersion);
+			System.Console.WriteLine("--------------------------------------------------------------------------------");
+		}
+	}
 }

--- a/src/DbUp/Engine/Git.cs
+++ b/src/DbUp/Engine/Git.cs
@@ -2,124 +2,114 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Configuration;
-using System.Linq;
-using System.Text;
-using System.IO;
 using System.Diagnostics;
 
-namespace DbUp.Engine
-{
-    /// <summary>
-    /// Git commands to find migrations that need to be executed since the last release
-    /// </summary>
-    public class Git
-    {
-        // Location of the git repository on the local machine
-        private string workingDir = "";
-        // git.exe should be on the user's path
-        private string gitExe = ""; //"git.exe";
-        // The branch you want to use
-        private string branch = ""; //"master";
-        // Name of the remote to use
-        private string remote = ""; //"origin";
+namespace DbUp.Engine {
+	/// <summary>
+	/// Git commands to find migrations that need to be executed since the last release
+	/// </summary>
+	public class Git {
+		// Location of the git repository on the local machine
+		private string workingDir = "";
+		// git.exe should be on the user's path
+		private string gitExe = ""; //"git.exe";
+		// The branch you want to use
+		private string branch = ""; //"master";
+		// Name of the remote to use
+		private string remote = ""; //"origin";
 
-        public Git(string workingDir, string branch)
-        {
-            this.workingDir = workingDir;
+		public Git(string workingDir, string branch) {
+			this.workingDir = workingDir;
 
-            Hashtable config = ConfigurationManager.GetSection("git") as Hashtable;
-            try
-            {
-                gitExe = (string)config["gitExe"] ?? gitExe;
-                remote = (string)config["remote"] ?? remote;
-                this.branch = branch ?? (string)config["branch"] ?? this.branch;
-            }
-            catch (KeyNotFoundException Ex)
-            {
-                Console.WriteLine("Missing git config parameter in app.config");
-                throw Ex;
-            }
-        }
+			Hashtable config = ConfigurationManager.GetSection("git") as Hashtable;
+			try {
+				gitExe = (string)config["gitExe"] ?? gitExe;
+				remote = (string)config["remote"] ?? remote;
+				this.branch = branch ?? (string)config["branch"] ?? this.branch;
+			} catch (KeyNotFoundException Ex) {
+				Console.WriteLine("Missing git config parameter in app.config");
+				throw Ex;
+			}
+		}
 
-        ///<summary>
-        /// Runs arbitrary git commands
-        /// </summary>
-        /// <returns>Git command result as a string</returns>
-        public string ExecuteCommand(string command)
-        {
-            Process git = new Process();
-            ProcessStartInfo gitStartInfo = new ProcessStartInfo();
-            gitStartInfo.FileName = this.gitExe;
-            gitStartInfo.Arguments = command;
-            gitStartInfo.UseShellExecute = false;
-            gitStartInfo.RedirectStandardOutput = true;
-            gitStartInfo.WorkingDirectory = this.workingDir;
-            git.StartInfo = gitStartInfo;
-            git.Start();
-            string gitOutput = git.StandardOutput.ReadToEnd();
-            git.WaitForExit();
+		///<summary>
+		/// Runs arbitrary git commands
+		/// </summary>
+		/// <returns>Git command result as a string</returns>
+		public string ExecuteCommand(string command) {
+			Process git = new Process();
+			ProcessStartInfo gitStartInfo = new ProcessStartInfo();
+			gitStartInfo.FileName = gitExe;
+			gitStartInfo.Arguments = command;
+			gitStartInfo.UseShellExecute = false;
+			gitStartInfo.RedirectStandardOutput = true;
+			gitStartInfo.RedirectStandardError = true;
+			gitStartInfo.WorkingDirectory = workingDir;
+			git.StartInfo = gitStartInfo;
+			git.Start();
+			string gitOutput = git.StandardOutput.ReadToEnd();
+			git.WaitForExit();
 
-            return gitOutput;
-        }
+			return gitOutput;
+		}
 
-        /// <summary>
-        /// Update the local repository with the lastest upstream changes
-        /// </summary>
-        public void UpdateLocalRepo()
-        {
-            RemoteUpdate();
-            CheckoutBranch();
-        }
+		/// <summary>
+		/// Update the local repository with the lastest upstream changes
+		/// </summary>
+		public void UpdateLocalRepo() {
+			RemoteUpdate();
+			CheckoutBranch();
+		}
 
-        /// <summary>
-        /// Make sure the local repository is on the correct branch. Assumes master will be used.
-        /// </summary>
-        private void CheckoutBranch()
-        {
-            // Checkout the desired branch
-            Console.WriteLine(this.ExecuteCommand("checkout " + branch));
-            // Update everything to match the remote branch exactly including removing untracked files if there are any
-            Console.WriteLine(this.ExecuteCommand("reset --hard " + remote + "/" + branch));
-        }
+		/// <summary>
+		/// Make sure the local repository is on the correct branch. Assumes master will be used.
+		/// </summary>
+		private void CheckoutBranch() {
+			// Checkout the desired branch
+			Console.WriteLine(ExecuteCommand("checkout " + branch));
+			// Update everything to match the remote branch exactly including removing untracked files if there are any
+			Console.WriteLine(ExecuteCommand("reset --hard " + remote + "/" + branch));
+		}
 
-        /// <summary>
-        /// Get the latest updates from the remote
-        /// </summary>
-        private void RemoteUpdate()
-        {
-            Console.WriteLine(this.ExecuteCommand("remote update " + remote));
-        }
+		/// <summary>
+		/// Get the latest updates from the remote
+		/// </summary>
+		private void RemoteUpdate() {
+			Console.WriteLine(ExecuteCommand("remote update " + remote));
+		}
 
-        /// <summary>
-        /// Pull the remote updates into the local repository (only from origin not upstream)
-        /// </summary>
-        private void PullChanges()
-        {
-            Console.WriteLine(this.ExecuteCommand("pull " + remote));
-        }
+		/// <summary>
+		/// Pull the remote updates into the local repository (only from origin not upstream)
+		/// </summary>
+		private void PullChanges() {
+			Console.WriteLine(ExecuteCommand("pull " + remote));
+		}
 
-        /// <summary>
-        /// Fetch the hash for the HEAD of the current branch
-        /// </summary>
-        /// <returns>Git hash as a string</returns>
-        public string HeadVersion()
-        {
-            return this.ExecuteCommand("rev-parse HEAD").Trim();
-        }
+		/// <summary>
+		/// Fetch the hash for the HEAD of the current branch
+		/// </summary>
+		/// <returns>Git hash as a string</returns>
+		public string HeadVersion() {
+			return ExecuteCommand("rev-parse HEAD").Trim();
+		}
 
-        /// <summary>
-        /// Find files in the local directory that need to be migrated to the target database
-        /// </summary>
-        /// <param name="databaseVersionHash">The most recent git hash stored in the target database to be updated</param>
-        /// <param name="repoVersionHash">The hash in the local repo that we want to compare the database hash to (typically HEAD)</param>
-        /// <returns>List of files prefixed with relative paths to the local repo</returns>
-        public string[] GetScripts(string databaseVersionHash, string repoVersionHash)
-        {
-            // Get all files that have been updated since the database was last updated
-            // (M)odified, (A)dded, (C)opied, (R)enamed
-            // (Renamed doesn't seem to do anything in testing but is here for consistency and claritys since -CM seem to catch renamed files)
-            var gitDiff = string.Format("diff -O diff-order-migrations-first --name-only --diff-filter=MACR {0}..{1}", databaseVersionHash, repoVersionHash);
-            return this.ExecuteCommand(gitDiff).Split('\n');
-        }
-    }
+		/// <summary>
+		/// Find files in the local directory that need to be migrated to the target database
+		/// </summary>
+		/// <param name="databaseVersionHash">The most recent git hash stored in the target database to be updated</param>
+		/// <param name="repoVersionHash">The hash in the local repo that we want to compare the database hash to (typically HEAD)</param>
+		/// <returns>List of files prefixed with relative paths to the local repo</returns>
+		public string[] GetScripts(string databaseVersionHash, string repoVersionHash) {
+			// Get all files that have been updated since the database was last updated
+			// (M)odified, (A)dded, (C)opied, (R)enamed
+			// (Renamed doesn't seem to do anything in testing but is here for consistency and claritys since -CM seem to catch renamed files)
+			return ExecuteCommand(
+				String.Format(
+					"diff -O diff-order-migrations-first --name-only --diff-filter=MACR {0}..{1}",
+					databaseVersionHash,
+					repoVersionHash
+				)
+			).Split('\n');
+		}
+	}
 }

--- a/src/DbUp/Engine/Output/ConsoleUpgradeLog.cs
+++ b/src/DbUp/Engine/Output/ConsoleUpgradeLog.cs
@@ -1,47 +1,47 @@
 ﻿using System;
 
-namespace DbUp.Engine.Output
-{
-    /// <summary>
-    /// A log that writes to the console in a colorful way.
-    /// </summary>
-    public class ConsoleUpgradeLog : IUpgradeLog
-    {
-        /// <summary>
-        /// Writes an informational message to the log.
-        /// </summary>
-        /// <param name="format">The format.</param>
-        /// <param name="args">The args.</param>
-        public void WriteInformation(string format, params object[] args)
-        {
-            Write(ConsoleColor.White, format, args);
-        }
+namespace DbUp.Engine.Output {
+	/// <summary>
+	/// A log that writes to the console in a colorful way.
+	/// </summary>
+	public class ConsoleUpgradeLog : IUpgradeLog {
+		/// <summary>
+		/// Writes an informational message to the log.
+		/// </summary>
+		/// <param name="format">The format.</param>
+		/// <param name="args">The args.</param>
+		public void WriteInformation(string format, params object[] args) {
+			Write(ConsoleColor.White, format, args);
+		}
 
-        /// <summary>
-        /// Writes an error message to the log.
-        /// </summary>
-        /// <param name="format">The format.</param>
-        /// <param name="args">The args.</param>
-        public void WriteError(string format, params object[] args)
-        {
-            Write(ConsoleColor.Red, format, args);
-        }
+		/// <summary>
+		/// Writes an error message to the log.
+		/// </summary>
+		/// <param name="format">The format.</param>
+		/// <param name="args">The args.</param>
+		public void WriteError(string format, params object[] args) {
+			Error(ConsoleColor.Red, format, args);
+		}
 
-        /// <summary>
-        /// Writes a warning message to the log.
-        /// </summary>
-        /// <param name="format">The format.</param>
-        /// <param name="args">The args.</param>
-        public void WriteWarning(string format, params object[] args)
-        {
-            Write(ConsoleColor.Yellow, format, args);
-        }
+		/// <summary>
+		/// Writes a warning message to the log.
+		/// </summary>
+		/// <param name="format">The format.</param>
+		/// <param name="args">The args.</param>
+		public void WriteWarning(string format, params object[] args) {
+			Write(ConsoleColor.Yellow, format, args);
+		}
 
-        private static void Write(ConsoleColor color, string format, object[] args)
-        {
-            Console.ForegroundColor = color;
-            Console.WriteLine(format, args);
-            Console.ResetColor();
-        }
-    }
+		private static void Write(ConsoleColor color, string format, object[] args) {
+			Console.ForegroundColor = color;
+			Console.WriteLine(format, args);
+			Console.ResetColor();
+		}
+
+		private static void Error(ConsoleColor color, string format, object[] args) {
+			Console.ForegroundColor = color;
+			Console.Error.WriteLine(format, args);
+			Console.ResetColor();
+		}
+	}
 }

--- a/src/DbUp/Engine/UpgradeEngine.cs
+++ b/src/DbUp/Engine/UpgradeEngine.cs
@@ -1,4 +1,5 @@
 ﻿using DbUp.Builder;
+using DbUp.Engine.Output;
 using Microsoft.SqlServer.Management.Common;
 using Microsoft.SqlServer.Management.Smo;
 using System;
@@ -39,7 +40,7 @@ namespace DbUp.Engine {
 		/// <param name="printAll">Print the contents of each of the scripts that will be run</param>
 		public void DryRun(string databaseVersionHash, string headVersion, string workingDir, bool printAll, string connectionString) {
 			if (printAll) {
-				GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).ForEach(i => configuration.Log.WriteInformation("{0}\r\n{1}\r\n\r\n", i.Name, i.Contents));
+				GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).ForEach(i => configuration.Log.WriteInformation("--{0}\r\n{1}\r\n\r\n", i.Name, i.Contents));
 			} else {
 				GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).ForEach(i => configuration.Log.WriteInformation("{0}", i.Name));
 			}
@@ -151,6 +152,15 @@ namespace DbUp.Engine {
 					configuration.Log.WriteError("Update failed due to an unexpected exception:\r\n{0}", ex.ToString());
 					return new DatabaseUpgradeResult(marked, false, ex);
 				}
+			}
+		}
+
+		/// <summary>
+		/// Returns the current logger
+		/// </summary>
+		public IUpgradeLog Log {
+			get {
+				return configuration.Log;
 			}
 		}
 	}

--- a/src/DbUp/Engine/UpgradeEngine.cs
+++ b/src/DbUp/Engine/UpgradeEngine.cs
@@ -1,207 +1,157 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using DbUp.Builder;
-using System.IO;
-using System.Diagnostics;
-using System.Text;
-using System.Data.SqlClient;
-using Microsoft.SqlServer.Management.Smo;
+﻿using DbUp.Builder;
 using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlServer.Management.Smo;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
 
-namespace DbUp.Engine
-{
-    /// <summary>
-    /// This class orchestrates the database upgrade process.
-    /// </summary>
-    public class UpgradeEngine
-    {
-        private readonly UpgradeConfiguration configuration;
-        private readonly string branch;
+namespace DbUp.Engine {
+	/// <summary>
+	/// This class orchestrates the database upgrade process.
+	/// </summary>
+	public class UpgradeEngine {
+		private readonly UpgradeConfiguration configuration;
+		private readonly string branch;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpgradeEngine"/> class.
-        /// </summary>
-        /// <param name="configuration">The configuration.</param>
-        public UpgradeEngine(UpgradeConfiguration configuration, string branch)
-        {
-            this.configuration = configuration;
-            this.branch = branch;
-        }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="UpgradeEngine"/> class.
+		/// </summary>
+		/// <param name="configuration">The configuration.</param>
+		public UpgradeEngine(UpgradeConfiguration configuration, string branch) {
+			this.configuration = configuration;
+			this.branch = branch;
+		}
 
-        /// <summary>
-        /// Determines whether the database is out of date and can be upgraded.
-        /// </summary>
-        public bool IsUpgradeRequired(string databaseVersionHash, string workingDir)
-        {
-            return GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).Count() != 0;
-        }
+		/// <summary>
+		/// Determines whether the database is out of date and can be upgraded.
+		/// </summary>
+		public bool IsUpgradeRequired(string databaseVersionHash, string workingDir) {
+			return GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).Count() != 0;
+		}
 
-        /// <summary>
-        /// Return a list of scripts that would be ran if this was not a dry run
-        /// </summary>
-        /// <param name="databaseVersionHash">The most recent database version</param>
-        /// <param name="workingDir">The local clone of the migrations repository</param>
-        /// <param name="printAll">Print the contents of each of the scripts that will be run</param>
-        public void DryRun(string databaseVersionHash, string headVersion, string workingDir, bool printAll, string connectionString)
-        {
-            if (printAll)
-            {
-                GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).ForEach(i => Console.WriteLine("{0}\r\n{1}\r\n\r\n", i.Name, i.Contents));
-            }
-            else
-            {
-                GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).ForEach(i => Console.WriteLine("{0}", i.Name));
-            }
+		/// <summary>
+		/// Return a list of scripts that would be ran if this was not a dry run
+		/// </summary>
+		/// <param name="databaseVersionHash">The most recent database version</param>
+		/// <param name="workingDir">The local clone of the migrations repository</param>
+		/// <param name="printAll">Print the contents of each of the scripts that will be run</param>
+		public void DryRun(string databaseVersionHash, string headVersion, string workingDir, bool printAll, string connectionString) {
+			if (printAll) {
+				GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).ForEach(i => configuration.Log.WriteInformation("{0}\r\n{1}\r\n\r\n", i.Name, i.Contents));
+			} else {
+				GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash).ForEach(i => configuration.Log.WriteInformation("{0}", i.Name));
+			}
 
-            PerformUpgrade(databaseVersionHash, headVersion, workingDir, connectionString, true);
-        }
+			PerformUpgrade(databaseVersionHash, headVersion, workingDir, connectionString, true);
+		}
 
-        /// <summary>
-        /// Tries to connect to the database.
-        /// </summary>
-        /// <param name="errorMessage">Any error message encountered.</param>
-        /// <returns></returns>
-        public bool TryConnect(out string errorMessage)
-        {
-            try
-            {
-                errorMessage = "";
-                configuration.ConnectionManager.ExecuteCommandsWithManagedConnection(dbCommandFactory =>
-                {
-                    using (var command = dbCommandFactory())
-                    {
-                        command.CommandText = "select 1";
-                        command.ExecuteScalar();
-                    }
-                });
-                return true;
-            }
-            catch (Exception ex)
-            {
-                errorMessage = ex.Message;
-                return false;
-            }
-        }
+		/// <summary>
+		/// Tries to connect to the database.
+		/// </summary>
+		/// <param name="errorMessage">Any error message encountered.</param>
+		/// <returns></returns>
+		public bool TryConnect(out string errorMessage) {
+			try {
+				errorMessage = "";
+				configuration.ConnectionManager.ExecuteCommandsWithManagedConnection(dbCommandFactory => {
+					using (var command = dbCommandFactory()) {
+						command.CommandText = "select 1";
+						command.ExecuteScalar();
+					}
+				});
+				return true;
+			} catch (Exception ex) {
+				errorMessage = ex.Message;
+				return false;
+			}
+		}
 
-        /// <summary>
-        /// Performs the database upgrade.
-        /// </summary>
-        public DatabaseUpgradeResult PerformUpgrade(string databaseVersionHash, string headVersion, string workingDir, string connectionString, bool dryRun = false)
-        {
-            var executed = new List<SqlScript>();
-            try
-            {
-                using (configuration.ConnectionManager.OperationStarting(configuration.Log, executed))
-                {
-                    configuration.Log.WriteInformation("Beginning database upgrade");
+		/// <summary>
+		/// Performs the database upgrade.
+		/// </summary>
+		public DatabaseUpgradeResult PerformUpgrade(string databaseVersionHash, string headVersion, string workingDir, string connectionString, bool dryRun = false) {
+			var executed = new List<SqlScript>();
+			try {
+				using (configuration.ConnectionManager.OperationStarting(configuration.Log, executed)) {
+					configuration.Log.WriteInformation("Beginning database upgrade");
 
-                    var scriptsToExecute = GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash);
+					var scriptsToExecute = GetScriptsToExecuteInsideOperation(workingDir, databaseVersionHash);
 
-                    if (scriptsToExecute.Count == 0)
-                    {
-                        configuration.Log.WriteInformation("No new scripts need to be executed - completing.");
-                        return new DatabaseUpgradeResult(executed, true, null);
-                    }
+					if (scriptsToExecute.Count == 0) {
+						configuration.Log.WriteInformation("No new scripts need to be executed - completing.");
+						return new DatabaseUpgradeResult(executed, true, null);
+					}
 
-                    configuration.ScriptExecutor.VerifySchema();
+					configuration.ScriptExecutor.VerifySchema();
 
-                    StringBuilder combinedContents = new StringBuilder();
-                    combinedContents.AppendLine("SET XACT_ABORT ON\r\nGO\r\nBEGIN TRANSACTION EndeavorRelease\r\nGO\r\n");
-                    foreach (var script in scriptsToExecute)
-                    {
-                        if (script.IsValid())
-                        {
-                            combinedContents.Append("\r\n\r\n" + script.Contents);
-                        }
-                    }
+					StringBuilder combinedContents = new StringBuilder();
+					combinedContents.Append("SET XACT_ABORT ON\r\nGO\r\nBEGIN TRANSACTION EndeavorRelease\r\nGO\r\n");
+					foreach (var script in scriptsToExecute) {
+						if (script.IsValid()) {
+							combinedContents.AppendFormat("\r\n\r\n{0}", script.Contents);
+						}
+					}
 
-                    // If it's a dry run rollback the transaction at the end so nothing is committed to the database
-                    if (dryRun)
-                    {
-                        combinedContents.AppendLine("\r\nROLLBACK TRANSACTION\r\nGO\r\n");
-                    }
-                    else
-                    {
-                        combinedContents.AppendLine("\r\nCOMMIT TRANSACTION\r\nGO\r\n");
-                    }
+					// If it's a dry run rollback the transaction at the end so nothing is committed to the database
+					combinedContents.AppendFormat("\r\n{0} TRANSACTION\r\nGO\r\n", dryRun ? "ROLLBACK" : "COMMIT");
 
-                    SqlScript combinedScript = new SqlScript(headVersion + ".sql", combinedContents.ToString());
-                    try
-                    {
-                        using (SqlConnection conn = new SqlConnection(connectionString))
-                        {
-                            Server db = new Server(new ServerConnection(conn));
-                            db.ConnectionContext.ExecuteNonQuery(combinedContents.ToString());
-                        }
-                        executed.Add(combinedScript);
-                        //configuration.Log.WriteInformation("Upgrade successful");
-                    }
-                    catch (Exception ex)
-                    {
-                        // Just throw the error for now until we know whether the rollback will work
-                        throw ex;
-                    }
-                    return new DatabaseUpgradeResult(executed, true, null);
-                }
-            }
-            catch (Exception ex)
-            {
-                if (ex.InnerException != null)
-                {
-                    configuration.Log.WriteError("Upgrade failed: " + ex.InnerException.Message);
+					SqlScript combinedScript = new SqlScript(headVersion + ".sql", combinedContents.ToString());
+					try {
+						using (SqlConnection conn = new SqlConnection(connectionString)) {
+							Server db = new Server(new ServerConnection(conn));
+							db.ConnectionContext.ExecuteNonQuery(combinedContents.ToString());
+						}
+						executed.Add(combinedScript);
+					} catch (Exception ex) {
+						// Just throw the error for now until we know whether the rollback will work
+						throw ex;
+					}
+					return new DatabaseUpgradeResult(executed, true, null);
+				}
+			} catch (Exception ex) {
+				configuration.Log.WriteError("Upgrade failed: {0}", ex.InnerException != null ? ex.InnerException.Message : ex.Message);
+				return new DatabaseUpgradeResult(executed, false, ex);
+			}
+		}
 
-                }
-                else
-                {
-                    configuration.Log.WriteError("Upgrade failed: " + ex.Message);
-                }
-                return new DatabaseUpgradeResult(executed, false, ex);
-            }
-        }
+		/// <summary>
+		/// Retrieve all the SQL scripts that need to be executed
+		/// </summary>
+		/// <param name="workingDir">The directory containing the scripts to be run on the database</param>
+		/// <param name="databaseVersionHash">The version hash the database was last upgraded to</param>
+		/// <param name="repoVersionHash">The version hash the database will be upgraded to</param>
+		/// <returns>List of SQL scripts including their names and contents</returns>
+		private List<SqlScript> GetScriptsToExecuteInsideOperation(string workingDir, string databaseVersionHash, string repoVersionHash = "HEAD") {
+			// Git repo must already be cloned into workspace
+			try {
+				var aGit = new Git(workingDir, branch);
+				aGit.UpdateLocalRepo();
+				return aGit.GetScripts(databaseVersionHash, repoVersionHash).Where(s => !String.IsNullOrEmpty(s)).Select(s => SqlScript.FromFile(s)).ToList();
+			} catch (Exception ex) {
+				configuration.Log.WriteError("Git commands failed to run: \r\n{0}", ex.ToString());
+				return new List<SqlScript>();
+			}
+		}
 
-        /// <summary>
-        /// Retrieve all the SQL scripts that need to be executed
-        /// </summary>
-        /// <param name="workingDir">The directory containing the scripts to be run on the database</param>
-        /// <param name="databaseVersionHash">The version hash the database was last upgraded to</param>
-        /// <param name="repoVersionHash">The version hash the database will be upgraded to</param>
-        /// <returns>List of SQL scripts including their names and contents</returns>
-        private List<SqlScript> GetScriptsToExecuteInsideOperation(string workingDir, string databaseVersionHash, string repoVersionHash = "HEAD")
-        {
-            // Git repo must already be cloned into workspace
-            try {
-                var aGit = new Git(workingDir, branch);
-                aGit.UpdateLocalRepo();
-                return aGit.GetScripts(databaseVersionHash,repoVersionHash).Where(s => !String.IsNullOrEmpty(s)).Select(s => SqlScript.FromFile(s)).ToList();
-            } catch (Exception ex) {
-                configuration.Log.WriteError("Git commands failed to run: \r\n{0}", ex.ToString());
-                return new List<SqlScript>();
-            }            
-        }
-
-        ///<summary>
-        /// Creates version record for any new migration scripts without executing them.
-        /// Useful for bringing development environments into sync with automated environments
-        ///</summary>
-        ///<returns></returns>
-        public DatabaseUpgradeResult UpdateDatabaseVersion(DatabaseVersion dbVersion, string headHash)
-        {
-            var marked = new List<SqlScript>();
-            using (configuration.ConnectionManager.OperationStarting(configuration.Log, marked))
-            {
-                try
-                {
-                    dbVersion.Version = headHash;
-                    configuration.Log.WriteInformation("Database updated successfully to version: " + headHash);
-                    return new DatabaseUpgradeResult(marked, true, null);
-                }
-                catch (Exception ex)
-                {
-                    configuration.Log.WriteError("Update failed due to an unexpected exception:\r\n{0}", ex.ToString());
-                    return new DatabaseUpgradeResult(marked, false, ex);
-                }
-            }
-        }
-    }
+		///<summary>
+		/// Creates version record for any new migration scripts without executing them.
+		/// Useful for bringing development environments into sync with automated environments
+		///</summary>
+		///<returns></returns>
+		public DatabaseUpgradeResult UpdateDatabaseVersion(DatabaseVersion dbVersion, string headHash) {
+			var marked = new List<SqlScript>();
+			using (configuration.ConnectionManager.OperationStarting(configuration.Log, marked)) {
+				try {
+					dbVersion.Version = headHash;
+					configuration.Log.WriteInformation("Database updated successfully to version: {0}", headHash);
+					return new DatabaseUpgradeResult(marked, true, null);
+				} catch (Exception ex) {
+					configuration.Log.WriteError("Update failed due to an unexpected exception:\r\n{0}", ex.ToString());
+					return new DatabaseUpgradeResult(marked, false, ex);
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Updated the printAll logic so it will print to the logger and not the console.

Updated the console logger's error method to write to standard error so that octopus will report an error.

Updated the git executeCommand method so that it does not write to standard error since git checkout [branch] will return "Already on [branch]" messages to standard error/warning which causes octopus to report an error.
